### PR TITLE
add-generated-files.diff is 404

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -18,10 +18,8 @@ EOF
 # Download cartesi machine
 RUN <<EOF
 set -e
-git clone --branch v0.19.0-test2 --depth 1 https://github.com/cartesi/machine-emulator.git
+git clone --branch v0.19.0 --depth 1 https://github.com/cartesi/machine-emulator.git
 cd machine-emulator
-wget https://github.com/cartesi/machine-emulator/releases/download/v0.19.0-test2/add-generated-files.diff
-patch -Np1 < add-generated-files.diff
 make bundle-boost
 EOF
 


### PR DESCRIPTION
update to v0.19.0 release seems to work.

I cannot actually test it because my build fails further down the line anyway, but it seems to resolve this specific issue:
```
#7 1.400 --2025-07-05 06:49:23--  https://github.com/cartesi/machine-emulator/releases/download/v0.19.0-test2/add-generated-files.diff
#7 1.419 Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
#7 1.419 Resolving github.com (github.com)... 140.82.121.3
#7 1.437 Connecting to github.com (github.com)|140.82.121.3|:443... connected.
#7 1.555 HTTP request sent, awaiting response... 404 Not Found
#7 1.787 2025-07-05 06:49:23 ERROR 404: Not Found.
#7 1.787
#7 ERROR: process "/bin/sh -c set -e\ngit clone --branch v0.19.0-test2 --depth 1 https://github.com/cartesi/machine-emulator.git\ncd machine-emulator\nwget https://github.com/cartesi/machine-emulator/releases/download/v0.19.0-test2/add-generated-files.diff\npatch -Np1 < add-generated-files.diff\nmake bundle-boost\n" did not complete successfully: exit code: 8
------
 > [4/6] RUN <<EOF (set -e...):
0.533 Cloning into 'machine-emulator'...
1.379 warning: refs/tags/v0.19.0-test2 453a11fe0f09985a116b43192f7c59642337d0a0 is not a commit!
404 Not Found
1.787 2025-07-05 06:49:23 ERROR 404: Not Found.
```