### PR TITLE
fix(builder): specify platform=linux/amd64

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux:base-devel
+FROM --platform=linux/amd64 archlinux:base-devel
 
 RUN pacman -Syyu --noconfirm && \
     pacman -S --noconfirm git wget vim emscripten lua libslirp pigz


### PR DESCRIPTION
So it can be built from aarch64 (M-series macs) or other non x64 hosts.

Naively running `make` on `main` would fail with:
```sh
❯ make
docker build --tag webcm/builder --file builder.Dockerfile --progress plain .
#0 building with "orbstack" instance using docker driver

#1 [internal] load build definition from builder.Dockerfile
#1 transferring dockerfile: 1.40kB done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/archlinux:base-devel
#2 ERROR: no match for platform in manifest: not found
------
 > [internal] load metadata for docker.io/library/archlinux:base-devel:
------
builder.Dockerfile:1
--------------------
   1 | >>> FROM archlinux:base-devel
   2 |
   3 |     RUN pacman -Syyu --noconfirm && \
--------------------
ERROR: failed to build: failed to solve: archlinux:base-devel: failed to resolve source metadata for docker.io/library/archlinux:base-devel: no match for platform in manifest: not found
make: *** [builder] Error 1
````