### PR TITLE
dx: improved build caching and dockerized steps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.cache
+.buildx-cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ emscripten-pty.js
 gh-pages
 *.wasm
 *.mjs
+.cache
+.buildx-cache

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ EMCC_CFLAGS=-Oz -g0 -std=gnu++23 \
     -sASYNCIFY \
     -sFETCH \
    	-sSTACK_SIZE=4MB \
-   	-sTOTAL_MEMORY=768MB
+   	-sTOTAL_MEMORY=768MB \
+   	-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,UTF8ToString,stringToUTF8
+PIGZ_LEVEL ?= 11
 SKEL_FILES=$(shell find skel -type f)
 SRC_FILES=$(shell find https-proxy -type f -name '*.cpp' -o -name '*.hpp' -o -name Makefile)
 
@@ -17,21 +19,30 @@ test: # Test
 	emrun index.html
 
 builder: builder.Dockerfile ## Build WASM cross compiler docker image
+ifeq ($(IS_WASM_TOOLCHAIN),true)
+	@echo "Skipping builder target (already inside builder container)"
+else
 	docker build --tag webcm/builder --file $< --progress plain .
+endif
 
 webcm.wasm webcm.mjs: webcm.cpp rootfs.ext2.zz linux.bin.zz emscripten-pty.js
 ifeq ($(IS_WASM_TOOLCHAIN),true)
 	em++ webcm.cpp -o webcm.mjs $(EMCC_CFLAGS)
 else
-	docker run --volume=.:/mnt --workdir=/mnt --user=$(shell id -u):$(shell id -g) --env=HOME=/tmp --rm -it webcm/builder make webcm.mjs
+	@mkdir -p .cache
+	docker run --volume=.:/mnt --workdir=/mnt --user=$(shell id -u):$(shell id -g) --env=HOME=/tmp --env=EM_CACHE=/mnt/.cache --env=PIGZ_LEVEL=$(PIGZ_LEVEL) --rm -it webcm/builder make webcm.mjs
 endif
 
 gh-pages: index.html webcm.mjs webcm.wasm webcm.mjs favicon.svg
 	mkdir -p $@
 	cp $^ $@/
 
-rootfs.ext2: rootfs.tar
-	xgenext2fs \
+rootfs.ext2: rootfs.tar builder
+ifeq ($(IS_WASM_TOOLCHAIN),true)
+	@test -f $@ || (echo "Error: $@ not found. This should be built on the host." && exit 1)
+else
+	docker run --volume=.:/mnt --workdir=/mnt --user=$(shell id -u):$(shell id -g) --env=HOME=/tmp --rm webcm/builder \
+	    xgenext2fs \
 	    --faketime \
 	    --allow-holes \
 	    --size-in-blocks 98304 \
@@ -39,18 +50,47 @@ rootfs.ext2: rootfs.tar
 	    --bytes-per-inode 4096 \
 	    --volume-label rootfs \
 	    --tarball $< $@
+endif
 
 rootfs.tar: rootfs.Dockerfile $(SKEL_FILES) $(SRC_FILES)
-	docker buildx build --progress plain --output type=tar,dest=$@ --file rootfs.Dockerfile .
+ifeq ($(IS_WASM_TOOLCHAIN),true)
+	@test -f $@ || (echo "Error: $@ not found. This should be built on the host." && exit 1)
+else
+	@mkdir -p .buildx-cache
+	docker buildx build --progress plain --cache-from type=local,src=.buildx-cache --output type=tar,dest=$@ --file rootfs.Dockerfile .
+endif
 
-emscripten-pty.js:
-	wget -O emscripten-pty.js https://raw.githubusercontent.com/mame/xterm-pty/f284cab414d3e20f27a2f9298540b559878558db/emscripten-pty.js
+emscripten-pty.js: builder
+ifeq ($(IS_WASM_TOOLCHAIN),true)
+	@test -f $@ || (echo "Error: $@ not found. This should be built on the host." && exit 1)
+else
+	@if [ ! -f $@ ]; then \
+		docker run --volume=.:/mnt --workdir=/mnt --user=$(shell id -u):$(shell id -g) --env=HOME=/tmp --rm webcm/builder \
+		    wget -O emscripten-pty.js https://raw.githubusercontent.com/mame/xterm-pty/f284cab414d3e20f27a2f9298540b559878558db/emscripten-pty.js; \
+	else \
+		echo "$@ already exists, skipping download"; \
+	fi
+endif
 
-linux.bin: ## Download linux.bin
-	wget -O linux.bin https://github.com/cartesi/machine-linux-image/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin
+linux.bin: builder ## Download linux.bin
+ifeq ($(IS_WASM_TOOLCHAIN),true)
+	@test -f $@ || (echo "Error: $@ not found. This should be built on the host." && exit 1)
+else
+	@if [ ! -f $@ ]; then \
+		docker run --volume=.:/mnt --workdir=/mnt --user=$(shell id -u):$(shell id -g) --env=HOME=/tmp --rm webcm/builder \
+		    wget -O linux.bin https://github.com/cartesi/machine-linux-image/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin; \
+	else \
+		echo "$@ already exists, skipping download"; \
+	fi
+endif
 
-%.zz: %
-	cat $< | pigz -cz -11 > $@
+%.zz: % builder
+ifeq ($(IS_WASM_TOOLCHAIN),true)
+	@test -f $@ || (echo "Error: $@ not found. This should be built on the host." && exit 1)
+else
+	docker run --volume=.:/mnt --workdir=/mnt --user=$(shell id -u):$(shell id -g) --env=HOME=/tmp --rm webcm/builder \
+	    sh -c "cat $< | pigz -cz -$(PIGZ_LEVEL) > $@"
+endif
 
 clean: ## Remove built files
 	rm -f webcm.mjs webcm.wasm rootfs.tar rootfs.ext2 rootfs.ext2.zz linux.bin.zz


### PR DESCRIPTION
For faster dev builds:
- allow lowering compression level, e.g: `PIGZ_LEVEL=3 make`
- Add emscripten cache etc... so we're not recompiling libc etc...  everytime

For more robust dev on macOS etc...:
- run steps using xgenext2fs in the docker builder img