### PR TITLE
ux: bind https-proxy to 127.254.254.254

### DIFF
--- a/webcm.cpp
+++ b/webcm.cpp
@@ -263,7 +263,7 @@ int main() {
     snprintf(config, sizeof(config), R"({
         "dtb": {
             "bootargs": "quiet earlycon=sbi console=hvc1 root=/dev/pmem0 rw init=/usr/sbin/cartesi-init",
-            "init": "date -s @%llu >> /dev/null && dnsmasq --address=/#/127.0.0.1 --local=/#/ --no-resolv && https-proxy 127.0.0.1 80 443 > /dev/null 2>&1 &",
+            "init": "date -s @%llu >> /dev/null && dnsmasq --address=/#/127.254.254.254 --local=/#/ --no-resolv && https-proxy 127.254.254.254 80 443 > /dev/null 2>&1 &",
             "entrypoint": "exec ash -l"
         },
         "ram": {"length": %llu},


### PR DESCRIPTION
Freeing up ports 80/443 so servers can naturally bind to localhost http ports, it's also nice to have outbound traffic going to a distinct IP