### PR TITLE
perf: 40% smaller https-proxy

### DIFF
--- a/https-proxy/Makefile
+++ b/https-proxy/Makefile
@@ -1,9 +1,8 @@
-CXXFLAGS=-std=gnu++23 -Wall -Wextra -Os
-HARDEN_CXXFLAGS=-fno-strict-aliasing -fno-strict-overflow -fhardened
-LDFLAGS=-lssl -lcrypto -static-libstdc++ -s
+CXXFLAGS=-std=gnu++23 -Wall -Wextra -Os -fno-rtti -fno-exceptions -DBOOST_NO_EXCEPTIONS -flto -ffunction-sections -fdata-sections -fno-strict-aliasing -fno-strict-overflow
+LDFLAGS=-lssl -lcrypto -static-libstdc++ -s -flto -Wl,--gc-sections -Wl,--as-needed
 
 https-proxy: https-proxy.cpp cert_store.cpp *.hpp
-	g++ https-proxy.cpp cert_store.cpp -o $@ $(CXXFLAGS) $(HARDEN_CXXFLAGS) $(LDFLAGS)
+	g++ https-proxy.cpp cert_store.cpp -o $@ $(CXXFLAGS) $(LDFLAGS)
 
 lint:
 	clang-tidy *.cpp *.hpp -- $(CXXFLAGS)

--- a/https-proxy/https-proxy.cpp
+++ b/https-proxy/https-proxy.cpp
@@ -16,18 +16,21 @@
 #include "cert_store.hpp"
 
 #include <boost/asio/dispatch.hpp>
+#include <boost/asio/read.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/strand.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/asio/ip/udp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/config.hpp>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <exception>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -35,6 +38,20 @@
 #include <thread>
 #include <vector>
 #include <openssl/ssl.h>
+
+// Provide boost::throw_exception implementation for -fno-exceptions build
+#ifdef BOOST_NO_EXCEPTIONS
+namespace boost {
+[[noreturn]] void throw_exception(std::exception const& e) {
+    std::cerr << "Fatal error: " << e.what() << "\n";
+    std::abort();
+}
+[[noreturn]] void throw_exception(std::exception const& e, boost::source_location const& /*loc*/) {
+    std::cerr << "Fatal error: " << e.what() << "\n";
+    std::abort();
+}
+} // namespace boost
+#endif
 
 namespace beast = boost::beast;   // from <boost/beast.hpp>
 namespace http = beast::http;     // from <boost/beast/http.hpp>
@@ -488,7 +505,7 @@ private:
 
 //------------------------------------------------------------------------------
 
-int main(int argc, char *argv[]) try {
+int main(int argc, char *argv[]) {
     // Check command line arguments.
     if (argc != 4) {
         std::cerr << "Usage: https-proxy <address> <port1> <port2>\n"
@@ -534,6 +551,4 @@ int main(int argc, char *argv[]) try {
     ioc.run();
 
     return EXIT_SUCCESS;
-} catch (const std::exception &e) {
-    std::cerr << "main() exception: " << e.what() << "\n";
 }


### PR DESCRIPTION
Reduce https-proxy binary size by over 40%, ~1.3-1.4MB => 800kb

Removing exceptions is the main ~hackish thing, drops ~100kb (900=>800kb)